### PR TITLE
adapt SPL06-007.cpp to arduino board 

### DIFF
--- a/src/SPL06-007.cpp
+++ b/src/SPL06-007.cpp
@@ -357,7 +357,15 @@ int32_t get_c00()
   tmp_MSB = i2c_eeprom_read_uint8_t(SPL_CHIP_ADDRESS, 0X13);
   tmp_LSB = i2c_eeprom_read_uint8_t(SPL_CHIP_ADDRESS, 0X14);
   tmp_XLSB = i2c_eeprom_read_uint8_t(SPL_CHIP_ADDRESS, 0X15);
-  tmp = (tmp_MSB & 0x80 ? 0xFFF00000 : 0) | ((uint32_t)tmp_MSB << 12) | ((uint32_t)tmp_LSB << 4) | (((uint32_t)tmp_XLSB & 0xF0) >> 4);
+	
+  //tmp = (tmp_MSB & 0x80 ? 0xFFF00000 : 0) | ((uint32_t)tmp_MSB << 12) | ((uint32_t)tmp_LSB << 4) | (((uint32_t)tmp_XLSB & 0xF0) >> 4);
+	
+ tmp_XLSB = tmp_XLSB >> 4;
+  tmp = (tmp_MSB << 8) | tmp_LSB;
+  tmp = (tmp << 4) | tmp_XLSB;
+  if(tmp >> 19)
+    tmp = tmp | 0XFFF00000; // Set left bits to one for 2's complement conversion of negitive number
+
   return tmp;
 }
 
@@ -395,7 +403,13 @@ int32_t get_c10()
   tmp_MSB = i2c_eeprom_read_uint8_t(SPL_CHIP_ADDRESS, 0X15); // 4 bits
   tmp_LSB = i2c_eeprom_read_uint8_t(SPL_CHIP_ADDRESS, 0X16); // 8 bits
   tmp_XLSB = i2c_eeprom_read_uint8_t(SPL_CHIP_ADDRESS, 0X17); // 8 bits
-  tmp = (tmp_MSB & 0x8 ? 0xFFF00000 : 0) | (((uint32_t)tmp_MSB & 0x0F) << 16) | ((uint32_t)tmp_LSB << 8) | (uint32_t)tmp_XLSB;
+  //tmp = (tmp_MSB & 0x8 ? 0xFFF00000 : 0) | (((uint32_t)tmp_MSB & 0x0F) << 16) | ((uint32_t)tmp_LSB << 8) | (uint32_t)tmp_XLSB;
+	
+  tmp_MSB = tmp_MSB & 0b00001111;
+  tmp = (tmp_MSB << 8) | tmp_LSB;
+  tmp = (tmp << 8) | tmp_XLSB;
+  if(tmp >> 19)
+    tmp = tmp | 0XFFF00000; // Set left bits to one for 2's complement conversion of negitive number
   return tmp;
 }
 


### PR DESCRIPTION
there are anomalies when converting to uint32_t in arduino because the max size of int in atmega in 16bit not 32bit and this is clear when using 1<<19 it doesnt work so i used the other direction shift tmp>>19. normally this changes will not affect the esp32 board but it should be tested.
![image](https://user-images.githubusercontent.com/84233310/118362997-cd9d9f80-b581-11eb-87cb-204d62f08b0f.png)
